### PR TITLE
Fix Void Linux package count in GetPackagesByDistro

### DIFF
--- a/src/system_info.cpp
+++ b/src/system_info.cpp
@@ -259,8 +259,7 @@ std::string SystemInfo::GetPackagesByDistro() {
         { "slackware",   "/var/lib/rpm"          },
         { "opensuse",    "/var/lib/zypp/db"      },
         { "gentoo",      "/var/db/pkg"           },
-        { "flatpak",     "/var/lib/flatpak/app"  },
-        { "void",        "/var/db/xbps"          }
+        { "flatpak",     "/var/lib/flatpak/app"  }
     };
 
     auto countSubDirs = [&](const std::string& path) -> int {
@@ -306,5 +305,11 @@ std::string SystemInfo::GetPackagesByDistro() {
 
         return out.str();
     }
+
+    // Void Linux
+    if (s_distroID == "void") {
+        return Exec("xbps-query -l 2>/dev/null | wc -l");
+    }
+
     return "-1";
 }


### PR DESCRIPTION
Void Linux installs packages via XBPS, stored in pkgdb-*.plist files.
The previous code counted subdirectories in /var/db/xbps, which is incorrect and showed misleading values (e.g., "7").

This patch adds a Void-specific case: it uses the already existing `xbps-query -l` command to list all packages and count the lines using `wc -l`, this provides the correct installed package count.
