### PR TITLE
feat: install default config on build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,18 @@ target_include_directories(${PROJECT_NAME} PRIVATE src)
 # Link libraries to the release executable
 target_link_libraries(${PROJECT_NAME} PRIVATE tomlplusplus::tomlplusplus)
 
-# Create config dir and copy ascii-art.txt and example_config.toml to $HOME/.config/nitch++/.ascii.txt and $HOME/.config/nitch++/config.toml
+# Create config dir and copy ascii-art.txt and example_config.toml to $HOME/.config/nitch++/.ascii.txt and $HOME/.config/nitch++/config.toml if they don't already exist
 add_custom_command(
     TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory "$ENV{HOME}/.config/nitch++/"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/.assets/ascii.txt" "$ENV{HOME}/.config/nitch++/.ascii.txt"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/config/example_config.toml" "$ENV{HOME}/.config/nitch++/config.toml"
+    COMMAND ${CMAKE_COMMAND}
+            -DDEST="$ENV{HOME}/.config/nitch++/.ascii.txt"
+            -DSRC="${CMAKE_SOURCE_DIR}/.assets/ascii.txt"
+            -P "${CMAKE_SOURCE_DIR}/cmake/copy_if_missing.cmake"
+    COMMAND ${CMAKE_COMMAND}
+            -DDEST="$ENV{HOME}/.config/nitch++/config.toml"
+            -DSRC="${CMAKE_SOURCE_DIR}/config/example_config.toml"
+            -P "${CMAKE_SOURCE_DIR}/cmake/copy_if_missing.cmake"
 )
 
 install(TARGETS ${PROJECT_NAME} DESTINATION /usr/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,11 +33,12 @@ target_include_directories(${PROJECT_NAME} PRIVATE src)
 # Link libraries to the release executable
 target_link_libraries(${PROJECT_NAME} PRIVATE tomlplusplus::tomlplusplus)
 
-# Create config dir and copy ascii-art.txt to $HOME/.config/nitch++/.ascii.txt
+# Create config dir and copy ascii-art.txt and example_config.toml to $HOME/.config/nitch++/.ascii.txt and $HOME/.config/nitch++/config.toml
 add_custom_command(
     TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E make_directory "$ENV{HOME}/.config/nitch++/"
     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/.assets/ascii.txt" "$ENV{HOME}/.config/nitch++/.ascii.txt"
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_SOURCE_DIR}/config/example_config.toml" "$ENV{HOME}/.config/nitch++/config.toml"
 )
 
 install(TARGETS ${PROJECT_NAME} DESTINATION /usr/bin)

--- a/README.md
+++ b/README.md
@@ -163,4 +163,4 @@ Output of `nitch++ --help`
 
 ### Configuration
 
-In order to use the config file, put the [example config file](./config/example_config.toml) into the config directory. By default `nitch++` will use `$XDG_CONFIG_HOME/nitch++/config.toml` as the path to your config file. However, you are able to change the path by setting `NITCHPP_CONFIG_FILE` environment variable to a path ending in `config.toml`
+By default `nitch++` will use `$XDG_CONFIG_HOME/nitch++/config.toml` as the path to your config file. However, you are able to change the path by setting `NITCHPP_CONFIG_FILE` environment variable to a path ending in `config.toml`

--- a/cmake/copy_if_missing.cmake
+++ b/cmake/copy_if_missing.cmake
@@ -1,0 +1,4 @@
+if(NOT EXISTS "${DEST}")
+    file(COPY "${SRC}" DESTINATION "$ENV{HOME}/.config/nitch++")
+    file(RENAME "$ENV{HOME}/.config/nitch++/example_config.toml" "${DEST}")
+endif()

--- a/cmake/copy_if_missing.cmake
+++ b/cmake/copy_if_missing.cmake
@@ -1,4 +1,3 @@
 if(NOT EXISTS "${DEST}")
-    file(COPY "${SRC}" DESTINATION "$ENV{HOME}/.config/nitch++")
-    file(RENAME "$ENV{HOME}/.config/nitch++/example_config.toml" "${DEST}")
+    file(COPY_FILE "${SRC}" "${DEST}")
 endif()


### PR DESCRIPTION
This PR updates the CMake build to automatically copy the default example configuration after the project is built.

Changes:
- Copies `example_config.toml` to the config directory
- Updates `README.md` to accommodate changes

This ensures that new users have a working nitch++ by default without manual setup.